### PR TITLE
Add sort by column to Leaderboard

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -26,11 +26,30 @@ def game():
 @app.route("/leaderboard")
 def leaderboard():
     players = [
-        {"ranking": 1, "player": "player1", "stat1": 40, "stat2": 20},
-        {"ranking": 2, "player": "player2", "stat1": 40, "stat2": 30},
+        {"ranking": 1, "player": "player1", "stat1": 70, "stat2": 20},
+        {"ranking": 2, "player": "player2", "stat1": 31, "stat2": 30},
         {"ranking": 3, "player": "player3", "stat1": 35, "stat2": 10},
+        {"ranking": 4, "player": "player4", "stat1": 35, "stat2": 10},       # ranking will probably be determined by combination of stats in the future
+        {"ranking": 5, "player": "player5", "stat1": 21, "stat2": 40},
+        {"ranking": 6, "player": "player6", "stat1": 65, "stat2": 60},
     ]
-    return render_template("leaderboard.html", players = players)
+
+    sort = request.args.get("sort")
+
+    if sort == "ranking":
+        players = sorted(players, key=lambda x: x["ranking"])
+    elif sort == "player":
+        players = sorted(players, key=lambda x: x["player"].lower())
+    elif sort == "stat1":
+        players = sorted(players, key=lambda x: x["stat1"], reverse=True)
+    elif sort == "stat2":
+        players = sorted(players, key=lambda x: x["stat2"], reverse=True)
+    else:
+        sort = "ranking"
+        players = sorted(players, key=lambda x: x["ranking"])
+
+
+    return render_template("leaderboard.html", players = players, sort=sort)
 
 
 @app.route("/profile")

--- a/app/templates/leaderboard.html
+++ b/app/templates/leaderboard.html
@@ -11,29 +11,51 @@
       
 
       <div class="p-3 pb-4 bg-dark text-white rounded shadow-lg mb-0" style="min-height: 90vh;">
-        <h1 class="mb-2 border-bottom text-center text-truncate d-block">Leaderboard</h1>
-        <div class="table-responsive border rounded">
-          <table class="table table-striped table-sm table-dark mb-0">
-            <thead class="table-light">
-            <tr>
-                <th class="col" style="width: 10%" scope="col">Ranking</th>
-                <th scope="col">Player</th>
-                <th scope="col">stat1</th>
-                <th scope="col">stat2</th>
-            </tr>
-            </thead>
-            <tbody class="bg-secondary">
-            {% for row in players %}
-            <tr>
-                <th scope="row">{{ row.ranking }}</th>
-                <td>{{ row.player }}</td>
-                <td>{{ row.stat1 }}</td>
-                <td>{{ row.stat2 }}</td>
-            </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
+        <h1 class="mb-4 border-bottom text-center text-truncate d-block">Leaderboard</h1>
+          <div class="table-responsive border rounded">
+            <table class="table table-striped table-md table-dark mb-0 table-bordered">
+
+
+
+
+              <thead class="table-light">
+              <tr>
+                  <th class="col text-center" style="width: 5%" scope="col">
+                    <a class = "text-dark text-decoration-none text-center {% if sort == 'ranking' %}text-decoration-underline{% endif %}" href="{{ url_for('leaderboard', sort='ranking') }}"> Ranking </a>
+                  </th>
+                  <th class = "text-center" scope="col">
+                    <a class = "text-dark text-decoration-none text-center {% if sort == 'player' %}text-decoration-underline{% endif %}" href="{{ url_for('leaderboard', sort='player') }}"> Player </a>
+                  </th>
+                  <th class = "text-center" scope="col">
+                    <a class = "text-dark text-decoration-none {% if sort == 'stat1' %}text-decoration-underline{% endif %}" href="{{ url_for('leaderboard', sort='stat1') }}"> stat1 </a>
+                  </th>
+                  <th class = "text-center" scope="col">
+                    <a class = "text-dark text-decoration-none {% if sort == 'stat2' %}text-decoration-underline{% endif %}" href="{{ url_for('leaderboard', sort='stat2') }}"> stat2 </a>
+                  </th>
+              </tr>
+              </thead>
+
+
+
+
+              <tbody class="bg-secondary">
+              {% for row in players %}
+              <tr>
+                  <th class = "text-center" scope="row">{{ row.ranking }}</th>
+                  <td class = "text-center">{{ row.player }}</td>
+                  <td class = "text-center">{{ row.stat1 }}</td>
+                  <td class = "text-center">{{ row.stat2 }}</td>
+              </tr>
+              {% endfor %}
+              </tbody>
+
+
+
+
+
+
+            </table>
+          </div>
       </div>
 
     </section>


### PR DESCRIPTION
- Some presentation changes to leaderboard
- Clicking a columns header should sort the rows by that column
- Increased the amount of hardcoded player leaderboard stat entries

Closes #29 