### PR TITLE
Add player profile page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -33,9 +33,27 @@ def leaderboard():
     return render_template("leaderboard.html", players = players)
 
 
-@app.route("/profile")
-def profile():
-    return "Profile page"
+@app.route("/profile/<username>")
+def profile(username):
+    fake_profiles={ # TODO: Remove when database is implemented
+        "phyric1":{
+            "username":"phyric1",
+            "gold":120,
+            "fastest_time":3.55,
+            "total_runs":10,
+            "dungeons_cleared":8,
+            "cards_collected":10,
+            "deck_size":4,
+            "trade_completed":3,
+            "favourite_card":"Tailwind"
+        }
+    }
+    player=fake_profiles.get(username)
+
+    if player is None:
+        abort(404)
+    
+    return render_template("profile.html",player=player, username=username)
 
 
 @app.route("/profile/<username>/inventory")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -31,7 +31,7 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint == 'profile' %}active{% endif %}"
-                            href="{{ url_for('profile') }}">Profile</a>
+                            href="{{ url_for('profile',username=username|default('phyric1')) }}">Profile</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint == 'login' %}active{% endif %}"

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -13,7 +13,7 @@
             <a class="btn btn-success">
                 Manage Deck
             </a>
-            <a href=href="{{ url_for('profile') }}" class="btn btn-outline-primary">
+            <a href="{{ url_for('profile',username=username) }}" class="btn btn-outline-primary">
                 Back to Profile
             </a>
         </div>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>{{ player.username }}'s Profile</h2>
+
+        <a href="{{ url_for('inventory', username=player.username) }}" class="btn btn-primary">
+            View Inventory
+        </a>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            Player Overview
+        </div>
+
+        <div class="card-body">
+            <p><strong>Username:</strong> {{ player.username }}</p>
+            <p><strong>Gold:</strong> {{ player.gold }}</p>
+            <p><strong>Fastest Time:</strong> {{ player.fastest_time }} minutes</p>
+            <p><strong>Total Runs:</strong> {{ player.total_runs }}</p>
+            <p><strong>Dungeons Cleared:</strong> {{ player.dungeons_cleared }}</p>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            Cards and Deck
+        </div>
+
+        <div class="card-body">
+            <p><strong>Cards Collected:</strong> {{ player.cards_collected }}</p>
+            <p><strong>Deck Size:</strong> {{ player.deck_size }}</p>
+            <p><strong>Favourite Card:</strong> {{ player.favourite_card }}</p>
+
+            <a href="{{ url_for('inventory', username=player.username) }}" class="btn btn-outline-primary">
+                Manage Inventory
+            </a>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            Trading
+        </div>
+
+        <div class="card-body">
+            <p><strong>Trades Completed:</strong> {{ player.trade_completed }}</p>
+
+            <a href="#" class="btn btn-success">
+                Go to Trading Page
+            </a>
+        </div>
+    </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
I added the username-based profile page at /profile/<username>. It currently uses temporary fake data because we do not have the database yet. The page shows the player's general stats and links to the inventory page at /profile/<username>/inventory. I also updated the Profile navigation link so it works with the username-based route.